### PR TITLE
Add support for chefspec 4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,15 @@
 PATH
   remote: .
   specs:
-    fauxbag (0.1.0)
-      chefspec
+    fauxbag (1.0.0)
+      chefspec (~> 4.0.x)
       multi_json
 
 GEM
   remote: https://rubygems.org/
   specs:
-    chef (11.10.4)
-      chef-zero (~> 1.7, >= 1.7.2)
+    chef (11.12.8)
+      chef-zero (>= 2.0.2, < 2.1)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
       highline (~> 1.6, >= 1.6.9)
@@ -19,25 +19,22 @@ GEM
       mixlib-cli (~> 1.4)
       mixlib-config (~> 2.0)
       mixlib-log (~> 1.3)
-      mixlib-shellout (~> 1.3)
+      mixlib-shellout (~> 1.4)
       net-ssh (~> 2.6)
       net-ssh-multi (~> 1.1)
-      ohai (~> 6.0)
+      ohai (~> 7.0.4)
       pry (~> 0.9)
-      puma (~> 1.6)
       rest-client (>= 1.0.4, < 1.7.0)
       yajl-ruby (~> 1.1)
-    chef-zero (1.7.3)
+    chef-zero (2.0.2)
       hashie (~> 2.0)
       json
       mixlib-log (~> 1.3)
-      moneta (< 0.7.0)
       rack
-    chefspec (3.2.0)
-      chef (~> 11.0)
+    chefspec (4.0.0)
+      chef (~> 11.12)
       fauxhai (~> 2.0)
-      i18n (>= 0.6.9, < 1.0.0)
-      rspec (~> 2.14)
+      rspec (~> 3.0)
     coderay (1.1.0)
     columnize (0.3.6)
     debugger (1.6.5)
@@ -48,36 +45,35 @@ GEM
     debugger-ruby_core_source (1.3.1)
     diff-lcs (1.2.5)
     erubis (2.7.0)
-    fauxhai (2.1.0)
+    fauxhai (2.1.2)
       net-ssh
       ohai
-    hashie (2.0.5)
+    hashie (2.1.1)
     highline (1.6.21)
-    i18n (0.6.9)
     ipaddress (0.8.0)
     json (1.8.1)
     method_source (0.8.2)
     mime-types (1.25.1)
     mixlib-authentication (1.3.0)
       mixlib-log
-    mixlib-cli (1.4.0)
+    mixlib-cli (1.5.0)
     mixlib-config (2.1.0)
     mixlib-log (1.6.0)
-    mixlib-shellout (1.3.0)
-    moneta (0.6.0)
-    multi_json (1.9.2)
-    net-ssh (2.8.0)
+    mixlib-shellout (1.4.0)
+    multi_json (1.10.1)
+    net-ssh (2.9.1)
     net-ssh-gateway (1.2.0)
       net-ssh (>= 2.6.5)
     net-ssh-multi (1.2.0)
       net-ssh (>= 2.6.5)
       net-ssh-gateway (>= 1.2.0)
-    ohai (6.20.0)
+    ohai (7.0.4)
       ipaddress
+      mime-types (~> 1.16)
       mixlib-cli
-      mixlib-config
+      mixlib-config (~> 2.0)
       mixlib-log
-      mixlib-shellout
+      mixlib-shellout (~> 1.2)
       systemu (~> 2.5.2)
       yajl-ruby
     pry (0.9.12.6)
@@ -87,23 +83,25 @@ GEM
     pry-debugger (0.2.2)
       debugger (~> 1.3)
       pry (~> 0.9.10)
-    puma (1.6.3)
-      rack (~> 1.2)
     rack (1.5.2)
     rake (10.1.1)
     rest-client (1.6.7)
       mime-types (>= 1.16)
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.7)
-    rspec-expectations (2.14.5)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.5)
-    slop (3.4.7)
+    rspec (3.0.0)
+      rspec-core (~> 3.0.0)
+      rspec-expectations (~> 3.0.0)
+      rspec-mocks (~> 3.0.0)
+    rspec-core (3.0.0)
+      rspec-support (~> 3.0.0)
+    rspec-expectations (3.0.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.0.0)
+    rspec-mocks (3.0.1)
+      rspec-support (~> 3.0.0)
+    rspec-support (3.0.0)
+    slop (3.5.0)
     systemu (2.5.2)
-    yajl-ruby (1.2.0)
+    yajl-ruby (1.2.1)
 
 PLATFORMS
   ruby

--- a/fauxbag.gemspec
+++ b/fauxbag.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9'
 
-  spec.add_dependency 'chefspec'
+  spec.add_dependency 'chefspec', '~> 4.0.x'
   spec.add_dependency 'multi_json'
 
   spec.add_development_dependency "bundler", "~> 1.5"

--- a/lib/fauxbag/load_databag_json.rb
+++ b/lib/fauxbag/load_databag_json.rb
@@ -44,6 +44,6 @@ module Fauxbag
   #
   # @return [String] Path to the spec file
   def current_example_dir
-    File.dirname(File.expand_path(example.metadata[:file_path]))
+    File.dirname(File.expand_path(RSpec.current_example.metadata[:file_path]))
   end
 end

--- a/lib/fauxbag/version.rb
+++ b/lib/fauxbag/version.rb
@@ -1,3 +1,3 @@
 module Fauxbag
-  VERSION = "0.1.0"
+  VERSION = "1.0.0"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 require 'fauxbag'
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
   config.order = 'random'


### PR DESCRIPTION
In order to support chefspec 4.0 and rspec 3.0, this commit updates the
dependencies to now require chefspec 4.0. In addition, due to a change
in rspec, the way we access the current spec metadata needed to be
changed to account for the example method no longer being available
within a spec. Instead we use RSpec.current_example as this is set
before each spec to the correct metadata for that spec.

[12800973138385](https://app.asana.com/0/0/12800973138385)
