### PR TITLE
Fix typo in Fauxbag Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,4 @@ end
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request
+5. Create a new Pull Request


### PR DESCRIPTION
This commit adds an `a` to the README.

[62278039969028](https://app.asana.com/0/62278039969028/62278039969028)