### PR TITLE
Setup github action workflow for github gem repo

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -1,0 +1,29 @@
+name: Build and Push Gem
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Build + Publish
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby 2.7
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.7.x
+
+    - name: Publish to Github Package Registry
+      run: |
+        mkdir -p $HOME/.gem
+        touch $HOME/.gem/credentials
+        chmod 0600 $HOME/.gem/credentials
+        printf -- "---\n:github: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+        gem build *.gemspec
+        gem push --KEY github --host https://rubygems.pkg.github.com/${OWNER} *.gem
+      env:
+        GEM_HOST_API_KEY: "Bearer ${{secrets.GITHUB_TOKEN}}"
+        OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/gem-version-check.yml
+++ b/.github/workflows/gem-version-check.yml
@@ -1,0 +1,17 @@
+name: Verify Gem Version Change
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Version Check
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Version Forget Me Not
+      uses: simplybusiness/version-forget-me-not@v2
+      env:
+        ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        VERSION_FILE_PATH: "lib/fauxbag/version.rb"

--- a/lib/fauxbag/version.rb
+++ b/lib/fauxbag/version.rb
@@ -1,3 +1,3 @@
 module Fauxbag
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
In order to use the github package repo for this gem as well as the
github action for pushing the gem, this pull request adds the
`gem-push.yml` file.

This pull request also adds a gem-version-check file to enforce the
bumping of gem versions on branch builds.

This pull request also includes a bump to the gem version.